### PR TITLE
Hackathon: Position() string function added

### DIFF
--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -177,6 +177,7 @@ public class FunctionsTest extends TestUtility {
     public void testPosition() throws SQLException {
         checkStringPositionFunc("position", "bC", "str_a_val", false, 2);
         checkStringPositionFunc("position", "bc", "str_a_val", false, 2);
+        checkStringPositionFunc("position", "aa", "str_a_val", false, 0);
         checkStringPositionFunc("position", "bC", "str_a_val", true, null);
     }
 }

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -117,7 +117,7 @@ public class FunctionsTest extends TestUtility {
     private void checkStringFunc(String func_name, String col_name, boolean is_null, String expected) throws SQLException {
         String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
                                    func_name, col_name, (is_null ? 1 : 0));
-        
+
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(sql);
         boolean exists = rs.next();
@@ -129,6 +129,21 @@ public class FunctionsTest extends TestUtility {
         }
         assertNoMoreRows(rs);
     }
+
+    private void checkStringPositionFunc(String func_name, String substring, String col_name, boolean is_null, Integer expected) throws SQLException {
+            String sql = String.format("SELECT %s(\'%s\' IN %s) AS result FROM data WHERE is_null = %s", func_name, substring, col_name, (is_null ? 1 : 0));
+
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(sql);
+            boolean exists = rs.next();
+            assert(exists);
+            if (is_null) {
+                checkIntRow(rs, new String[]{"result"}, new int[1]);
+            } else {
+                checkIntRow(rs, new String[]{"result"}, new int[]{expected});
+            }
+            assertNoMoreRows(rs);
+        }
      
     /**
      * Tests usage of trig udf functions
@@ -158,5 +173,10 @@ public class FunctionsTest extends TestUtility {
         checkStringFunc("lower", "str_a_val", false, "abcdef");
         checkStringFunc("lower", "str_a_val", true, null);
     }
-
+    @Test
+    public void testPosition() throws SQLException {
+        checkStringPositionFunc("position", "bC", "str_a_val", false, 2);
+        checkStringPositionFunc("position", "bc", "str_a_val", false, 2);
+        checkStringPositionFunc("position", "bC", "str_a_val", true, null);
+    }
 }

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1785,6 +1785,11 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // TODO(tanujnay112): no op codes for lower and upper yet
 
+  // position
+  CreateProcedure(txn, postgres::POSITION_PRO_OID, "position", postgres::INTERNAL_LANGUAGE_OID,
+			      postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type, str_type}, {str_type}, {}, str_type, "", true);
+
+
   BootstrapProcContexts(txn);
 }
 
@@ -1825,6 +1830,11 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
+
+  func_context = new execution::functions::FunctionContext("position", type::TypeId::INTEGER, {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
+	                                                         execution::ast::Builtin::Position, true);
+  SetProcCtxPtr(txn, postgres::POSITION_PRO_OID, func_context);
+
   txn->RegisterAbortAction([=]() { delete func_context; });
 }
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1778,6 +1778,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 #undef BOOTSTRAP_TRIG_FN
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
+  auto int_type = GetTypeOidForType(type::TypeId::INTEGER);
 
   // lower
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
@@ -1787,7 +1788,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // position
   CreateProcedure(txn, postgres::POSITION_PRO_OID, "position", postgres::INTERNAL_LANGUAGE_OID,
-			      postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type, str_type}, {str_type}, {}, str_type, "", true);
+			      postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str1", "str2"}, {str_type, str_type}, {str_type, str_type}, {}, int_type, "", true);
 
 
   BootstrapProcContexts(txn);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1788,8 +1788,8 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // position
   CreateProcedure(txn, postgres::POSITION_PRO_OID, "position", postgres::INTERNAL_LANGUAGE_OID,
-			      postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str1", "str2"}, {str_type, str_type}, {str_type, str_type}, {}, int_type, "", true);
-
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str1", "str2"}, {str_type, str_type},
+                  {str_type, str_type}, {}, int_type, "", true);
 
   BootstrapProcContexts(txn);
 }
@@ -1832,8 +1832,9 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
 
-  func_context = new execution::functions::FunctionContext("position", type::TypeId::INTEGER, {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
-	                                                         execution::ast::Builtin::Position, true);
+  func_context = new execution::functions::FunctionContext("position", type::TypeId::INTEGER,
+                                                           {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Position, true);
   SetProcCtxPtr(txn, postgres::POSITION_PRO_OID, func_context);
 
   txn->RegisterAbortAction([=]() { delete func_context; });

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2254,6 +2254,43 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::StringVal;
       break;
     }
+    case ast::Builtin::Position: {
+      // check to make sure this function has three arguments
+      if (!CheckArgCount(call, 3)) {
+        return;
+      }
+
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
+
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // checking to see if the third argument is a string
+      resolved_type = Resolve(call->Arguments()[2]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // this function returns a string
+      sql_type = ast::BuiltinType::Integer;
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string call!!");
   }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2642,6 +2642,10 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
       CheckBuiltinStringCall(call, builtin);
       break;
     }
+    case ast::Builtin::Position: {
+      CheckBuiltinStringCall(call, builtin);
+      break;
+    }
     default: {
       UNREACHABLE("Unhandled builtin!");
     }

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -370,21 +370,19 @@ void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const 
     return;
   }
 
-  auto search_str_view = std::string(search_str.StringView());
-  auto search_sub_str_view = std::string(search_sub_str.StringView());
+  auto search_str_view = search_str.StringView();
+  auto search_sub_str_view = search_sub_str.StringView();
 
   // Postgres performs a case insensitive search for Position()
-  std::transform(search_sub_str_view.begin(), search_sub_str_view.end(), search_sub_str_view.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  std::transform(search_str_view.begin(), search_str_view.end(), search_str_view.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+  auto it =
+      std::search(search_str_view.begin(), search_str_view.end(), search_sub_str_view.begin(),
+                  search_sub_str_view.end(), [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); });
+  auto found = (it - search_str_view.begin());
 
-  std::size_t found = search_str_view.find(search_sub_str_view);
-
-  if (found != std::string::npos) {
-    *pos = Integer(found + 1);
-  } else {
+  if (found == search_str_view.length()) {
     *pos = Integer(0);
+  } else {
+    *pos = Integer(found + 1);
   }
 }
 }  // namespace terrier::execution::sql

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -367,10 +367,16 @@ void StringFunctions::Right(UNUSED_ATTRIBUTE exec::ExecutionContext *ctx, String
 void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str, const StringVal &search_sub_str) {
   if (search_str.is_null_ || search_sub_str.is_null_) {
     *pos = Integer::Null();
+    return;
   }
 
-  auto search_str_view = search_str.StringView();
-  auto search_sub_str_view = search_sub_str.StringView();
+  auto search_str_view = std::string(search_str.StringView());
+  auto search_sub_str_view = std::string(search_sub_str.StringView());
+
+  // Postgres performs a case insensitive search for Position()
+  std::transform(search_sub_str_view.begin(), search_sub_str_view.end(), search_sub_str_view.begin(), [](unsigned char c){ return std::tolower(c); });
+  std::transform(search_str_view.begin(), search_str_view.end(), search_str_view.begin(), [](unsigned char c){ return std::tolower(c); });
+
   std::size_t found = search_str_view.find(search_sub_str_view);
 
   if (found != std::string::npos) {

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -361,6 +361,22 @@ void StringFunctions::Right(UNUSED_ATTRIBUTE exec::ExecutionContext *ctx, String
   } else {
     *result = StringVal(str.Content() + len, str.len_ - len);
   }
+
 }
 
+void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str, const StringVal &search_sub_str) {
+  if (search_str.is_null_ || search_sub_str.is_null_) {
+    *pos = Integer::Null();
+  }
+
+  auto search_str_view = search_str.StringView();
+  auto search_sub_str_view = search_sub_str.StringView();
+  std::size_t found = search_str_view.find(search_sub_str_view);
+
+  if (found != std::string::npos) {
+    *pos = Integer(found + 1);
+  } else {
+    *pos = Integer(0);
+  }
+}
 }  // namespace terrier::execution::sql

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -361,10 +361,10 @@ void StringFunctions::Right(UNUSED_ATTRIBUTE exec::ExecutionContext *ctx, String
   } else {
     *result = StringVal(str.Content() + len, str.len_ - len);
   }
-
 }
 
-void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str, const StringVal &search_sub_str) {
+void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str,
+                               const StringVal &search_sub_str) {
   if (search_str.is_null_ || search_sub_str.is_null_) {
     *pos = Integer::Null();
     return;
@@ -374,8 +374,10 @@ void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const 
   auto search_sub_str_view = std::string(search_sub_str.StringView());
 
   // Postgres performs a case insensitive search for Position()
-  std::transform(search_sub_str_view.begin(), search_sub_str_view.end(), search_sub_str_view.begin(), [](unsigned char c){ return std::tolower(c); });
-  std::transform(search_str_view.begin(), search_str_view.end(), search_str_view.begin(), [](unsigned char c){ return std::tolower(c); });
+  std::transform(search_sub_str_view.begin(), search_sub_str_view.end(), search_sub_str_view.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  std::transform(search_str_view.begin(), search_str_view.end(), search_str_view.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
 
   std::size_t found = search_str_view.find(search_sub_str_view);
 

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2346,6 +2346,10 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       VisitBuiltinStringCall(call, builtin);
       break;
     }
+    case ast::Builtin::Position: {
+      VisitBuiltinStringCall(call, builtin);
+      break;
+    }
 
     default: {
       UNREACHABLE("Builtin not supported!");

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2049,6 +2049,11 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
       Emitter()->Emit(Bytecode::Lower, exec_ctx, ret, input_string);
       break;
     }
+    case ast::Builtin::Position: {
+      LocalVar sub_string = VisitExpressionForRValue(call->Arguments()[2]);
+      Emitter()->Emit(Bytecode::Position, exec_ctx, ret, input_string, sub_string);
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string function!");
   }

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1864,6 +1864,15 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
+  OP(Position) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *search_str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    auto *search_sub_str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpPosition(exec_ctx, result, search_str, search_sub_str);
+    DISPATCH_NEXT();
+  }
+
   OP(LPad) : {
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -80,4 +80,6 @@ constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
 
+constexpr proc_oid_t POSITION_PRO_OID = proc_oid_t(105);
+
 }  // namespace terrier::catalog::postgres

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -245,6 +245,7 @@ namespace terrier::execution::ast {
                                                                         \
   /* String functions */                                                \
   F(Lower, lower)
+  F(Position, position)
 
 /**
  * Enum of builtins

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -244,7 +244,7 @@ namespace terrier::execution::ast {
   F(GetParamString, getParamString)                                     \
                                                                         \
   /* String functions */                                                \
-  F(Lower, lower)
+  F(Lower, lower)                                                       \
   F(Position, position)
 
 /**

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -122,6 +122,11 @@ class EXPORT StringFunctions {
    * Converts the string to upper case
    */
   static void Upper(exec::ExecutionContext *ctx, StringVal *result, const StringVal &str);
+
+  /**
+   * Finds the first matching position of a substring in a string
+   */
+   static void Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str, const StringVal &search_sub_str);
 };
 
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -126,7 +126,8 @@ class EXPORT StringFunctions {
   /**
    * Finds the first matching position of a substring in a string
    */
-   static void Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str, const StringVal &search_sub_str);
+  static void Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str,
+                       const StringVal &search_sub_str);
 };
 
 }  // namespace terrier::execution::sql

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1365,6 +1365,11 @@ VM_OP_WARM void OpLower(terrier::execution::exec::ExecutionContext *ctx, terrier
   terrier::execution::sql::StringFunctions::Lower(ctx, result, *str);
 }
 
+VM_OP_WARM void OpPosition(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::Integer *result,
+                           const terrier::execution::sql::StringVal *search_str, const terrier::execution::sql::StringVal *search_sub_str) {
+  terrier::execution::sql::StringFunctions::Position(ctx, result, *search_str, *search_sub_str);
+}
+
 VM_OP_WARM void OpLPad(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                        const terrier::execution::sql::StringVal *str, const terrier::execution::sql::Integer *len,
                        const terrier::execution::sql::StringVal *pad) {

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1366,7 +1366,8 @@ VM_OP_WARM void OpLower(terrier::execution::exec::ExecutionContext *ctx, terrier
 }
 
 VM_OP_WARM void OpPosition(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::Integer *result,
-                           const terrier::execution::sql::StringVal *search_str, const terrier::execution::sql::StringVal *search_sub_str) {
+                           const terrier::execution::sql::StringVal *search_str,
+                           const terrier::execution::sql::StringVal *search_sub_str) {
   terrier::execution::sql::StringFunctions::Position(ctx, result, *search_str, *search_sub_str);
 }
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -475,7 +475,8 @@ namespace terrier::execution::vm {
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Upper, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
-                                                                                                                      \
+  F(Position, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)
+
   /* String functions */                                                                                              \
   F(GetParamBool, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
   F(GetParamTinyInt, OperandType::Local, OperandType::Local, OperandType::Local)                                      \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -475,8 +475,8 @@ namespace terrier::execution::vm {
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Upper, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
-  F(Position, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)
-
+  F(Position, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                         \
+                                                                                                                      \
   /* String functions */                                                                                              \
   F(GetParamBool, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
   F(GetParamTinyInt, OperandType::Local, OperandType::Local, OperandType::Local)                                      \


### PR DESCRIPTION
Implemented the PostgreSQL standard Position function with tests. 

Usage: 
```
SELECT POSITION('b' in 'BOMB') FROM FOO; 
(Result: 1)
```