### PR TITLE
Implement LENGTH, SQRT, CBRT, ROUND

### DIFF
--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -149,6 +149,17 @@ public class FunctionsTest extends TestUtility {
         checkDoubleFunc("tan", "double_val", false, -0.230318);
         checkDoubleFunc("tan", "double_val", true, null);
     }
+
+    @Test
+    public void testSqrt() throws SQLException {
+        checkDoubleFunc("sqrt", "double_val", false, 3.512834);
+        checkDoubleFunc("sqrt", "double_val", true, null);
+    }
+    @Test
+    public void testCbrt() throws SQLException {
+        checkDoubleFunc("cbrt", "double_val", false, 2.310850);
+        checkDoubleFunc("cbrt", "double_val", true, null);
+    }
     
     /**
      * String Functions

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -236,6 +236,7 @@ public class FunctionsTest extends TestUtility {
     public void testRoundUpTo() throws SQLException {
         checkRoundUpToFunc("roundupto", "double_val", "1", false, 12.3);
         checkRoundUpToFunc("roundupto", "double_val", "1", true, null);
+    }
 
     /**
      * String Functions

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -130,8 +130,8 @@ public class FunctionsTest extends TestUtility {
         assertNoMoreRows(rs);
     }
 
-    private void checkRoundFunc(String func_name, String col_name, String precision, boolean is_null, Double expected) throws SQLException {
-        String sql = String.format("SELECT %s(%s,%s) AS result FROM data WHERE is_null = %s",
+    private void checkDoubleRoundFunc(String func_name, String col_name, int precision, boolean is_null, Double expected) throws SQLException {
+        String sql = String.format("SELECT %s(%s,%d) AS result FROM data WHERE is_null = %s",
                                    func_name, col_name, precision, (is_null ? 1 : 0));
 
         Statement stmt = conn.createStatement();
@@ -246,8 +246,8 @@ public class FunctionsTest extends TestUtility {
     public void testRound() throws SQLException {
         checkDoubleFunc("round", "double_val", false, 12.0);
         checkDoubleFunc("round", "double_val", true, null);
-        checkRoundFunc("round", "double_val", "1", false, 12.3);
-        checkRoundFunc("round", "double_val", "1", true, null);
+        checkDoubleRoundFunc("round", "double_val", 1, false, 12.3);
+        checkDoubleRoundFunc("round", "double_val", 1, true, null);
     }
 
     /**

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -169,8 +169,13 @@ public class FunctionsTest extends TestUtility {
     @Test
     public void testRound() throws SQLException {
         checkDoubleFunc("round", "double_val", false, 12.0);
+        checkDoubleFunc("round", "double_val", true, null);
     }
-
+    @Test
+    public void testRoundUpTo() throws SQLException {
+        checkRoundUpToFunc("roundupto", "double_val", "1", false, 12.3);
+        checkRoundUpToFunc("roundupto", "double_val", "1", true, null);
+    }
     /**
      * String Functions
      */

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -114,18 +114,23 @@ public class FunctionsTest extends TestUtility {
         assertNoMoreRows(rs);
     }
 
-    private void checkRoundFunc(String func_name, String col_name, boolean is_null, Integer expected) throws SQLException {
-        String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
-                                   func_name, col_name, (is_null ? 1 : 0));
+    private void checkRoundUpToFunc(String func_name, String col_name, String decimal_position, boolean is_null, Double expected) throws SQLException {
+        String sql = String.format("SELECT %s(%s,%s) AS result FROM data WHERE is_null = %s",
+                                   func_name, col_name, decimal_position, (is_null ? 1 : 0));
 
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(sql);
         boolean exists = rs.next();
         assert(exists);
-        checkIntRow(rs, new String[]{"result"}, new int[]{expected});
+        if (is_null) {
+            checkDoubleRow(rs, new String[]{"result"}, new Double[]{null});
+        } else {
+            checkDoubleRow(rs, new String[]{"result"}, new Double[]{expected});
+        }
         assertNoMoreRows(rs);
     }
-    
+
+
     private void checkStringFunc(String func_name, String col_name, boolean is_null, String expected) throws SQLException {
         String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
                                    func_name, col_name, (is_null ? 1 : 0));
@@ -163,8 +168,9 @@ public class FunctionsTest extends TestUtility {
     }
     @Test
     public void testRound() throws SQLException {
-        checkRoundFunc("round", "double_val", false, 12);
+        checkDoubleFunc("round", "double_val", false, 12.0);
     }
+
     /**
      * String Functions
      */

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -130,9 +130,9 @@ public class FunctionsTest extends TestUtility {
         assertNoMoreRows(rs);
     }
 
-    private void checkRoundUpToFunc(String func_name, String col_name, String scale, boolean is_null, Double expected) throws SQLException {
+    private void checkFuncRound2(String func_name, String col_name, String precision, boolean is_null, Double expected) throws SQLException {
         String sql = String.format("SELECT %s(%s,%s) AS result FROM data WHERE is_null = %s",
-                                   func_name, col_name, scale, (is_null ? 1 : 0));
+                                   func_name, col_name, precision, (is_null ? 1 : 0));
 
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(sql);
@@ -233,9 +233,9 @@ public class FunctionsTest extends TestUtility {
         checkDoubleFunc("round", "double_val", true, null);
     }
     @Test
-    public void testRoundUpTo() throws SQLException {
-        checkRoundUpToFunc("roundupto", "double_val", "1", false, 12.3);
-        checkRoundUpToFunc("roundupto", "double_val", "1", true, null);
+    public void testRound2() throws SQLException {
+        checkFuncRound2("round", "double_val", "1", false, 12.3);
+        checkFuncRound2("round", "double_val", "1", true, null);
     }
 
     /**

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -129,6 +129,22 @@ public class FunctionsTest extends TestUtility {
         }
         assertNoMoreRows(rs);
     }
+
+    private void checkStringFunc(String func_name, String col_name, boolean is_null, int expected) throws SQLException {
+        String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
+                                   func_name, col_name, (is_null ? 1 : 0));
+
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        boolean exists = rs.next();
+        assert(exists);
+        if (is_null) {
+            checkIntegerRow(rs, new String[]{"result"}, new Integer[]{null});
+        } else {
+            checkIntegerRow(rs, new String[]{"result"}, new Integer[]{expected});
+        }
+        assertNoMoreRows(rs);
+    }
      
     /**
      * Tests usage of trig udf functions

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -174,5 +174,10 @@ public class FunctionsTest extends TestUtility {
         checkStringFunc("lower", "str_a_val", false, "abcdef");
         checkStringFunc("lower", "str_a_val", true, null);
     }
+    @Test
+    public void testLength() throws SQLException {
+        checkStringFunc("length", "str_a_val", false, 6);
+        checkStringFunc("length", "str_a_val", true, null);
+    }
 
 }

--- a/script/testing/junit/src/FunctionsTest.java
+++ b/script/testing/junit/src/FunctionsTest.java
@@ -113,6 +113,18 @@ public class FunctionsTest extends TestUtility {
         }
         assertNoMoreRows(rs);
     }
+
+    private void checkRoundFunc(String func_name, String col_name, boolean is_null, Integer expected) throws SQLException {
+        String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
+                                   func_name, col_name, (is_null ? 1 : 0));
+
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        boolean exists = rs.next();
+        assert(exists);
+        checkIntRow(rs, new String[]{"result"}, new int[]{expected});
+        assertNoMoreRows(rs);
+    }
     
     private void checkStringFunc(String func_name, String col_name, boolean is_null, String expected) throws SQLException {
         String sql = String.format("SELECT %s(%s) AS result FROM data WHERE is_null = %s",
@@ -149,7 +161,10 @@ public class FunctionsTest extends TestUtility {
         checkDoubleFunc("tan", "double_val", false, -0.230318);
         checkDoubleFunc("tan", "double_val", true, null);
     }
-    
+    @Test
+    public void testRound() throws SQLException {
+        checkRoundFunc("round", "double_val", false, 12);
+    }
     /**
      * String Functions
      */

--- a/script/testing/junit/src/TestUtility.java
+++ b/script/testing/junit/src/TestUtility.java
@@ -53,6 +53,21 @@ public class TestUtility {
     }
 
     /**
+     * Check a single row of integer queried values against expected values
+     *
+     * @param rs              resultset, with cursor at the desired row
+     * @param columns         column names
+     * @param expected expected values of columns
+     */
+    public void checkIntegerRow(ResultSet rs, String [] columns, Integer [] expected) throws SQLException {
+        assertEquals(columns.length, expected.length);
+        for (int i=0; i<columns.length; i++) {
+            Integer val = (Integer)rs.getInt(columns[i]);
+            assertEquals(expected[i], val);
+        }
+    }
+
+    /**
      * Check a single row of real queried values against expected values
      *
      * @param rs              resultset, with cursor at the desired row
@@ -83,11 +98,7 @@ public class TestUtility {
         assertEquals(columns.length, expected.length);
         for (int i = 0; i < columns.length; i++) {
             String val = (String)rs.getObject(columns[i]);
-            if (expected[i] == null) {
-                assertEquals(expected[i], val);
-            } else {
-                assertEquals(expected[i], val);
-            }
+            assertEquals(expected[i], val);
         }
     }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -166,8 +166,8 @@ proc_oid_t CatalogAccessor::GetProcOid(const std::string &procname, const std::v
   return catalog::INVALID_PROC_OID;
 }
 
-bool CatalogAccessor::SetProcCtxPtr(proc_oid_t proc_oid, const execution::functions::FunctionContext *udf_context) {
-  return dbc_->SetProcCtxPtr(txn_, proc_oid, udf_context);
+bool CatalogAccessor::SetProcCtxPtr(proc_oid_t proc_oid, const execution::functions::FunctionContext *func_context) {
+  return dbc_->SetProcCtxPtr(txn_, proc_oid, func_context);
 }
 
 common::ManagedPointer<execution::functions::FunctionContext> CatalogAccessor::GetProcCtxPtr(proc_oid_t proc_oid) {

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1835,7 +1835,7 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
   // round up to
   func_context = new execution::functions::FunctionContext("roundupto", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
-                                                                execution::ast::Builtin::RoundUpTo);
+                                                           execution::ast::Builtin::RoundUpTo);
   txn->RegisterAbortAction([=]() { delete func_context; });
   SetProcCtxPtr(txn, postgres::ROUNDUPTO_PRO_OID, func_context);
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1775,6 +1775,12 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
 
+  // sqrt
+  BOOTSTRAP_TRIG_FN("sqrt", postgres::SQRT_PRO_OID, execution::ast::Builtin::Sqrt)
+
+  // cbrt
+  BOOTSTRAP_TRIG_FN("cbrt", postgres::CBRT_PRO_OID, execution::ast::Builtin::Cbrt)
+
 #undef BOOTSTRAP_TRIG_FN
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
@@ -1820,6 +1826,12 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
+
+  // sqrt
+  BOOTSTRAP_TRIG_FN("sqrt", postgres::SQRT_PRO_OID, execution::ast::Builtin::Sqrt)
+
+  // cbrt
+  BOOTSTRAP_TRIG_FN("cbrt", postgres::CBRT_PRO_OID, execution::ast::Builtin::Cbrt)
 #undef BOOTSTRAP_TRIG_FN
 
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1800,8 +1800,8 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
 #undef BOOTSTRAP_TRIG_FN
 
-  // roundupto
-  CreateProcedure(txn, postgres::ROUNDUPTO_PRO_OID, "roundupto", postgres::INTERNAL_LANGUAGE_OID,
+  // round2
+  CreateProcedure(txn, postgres::ROUND2_PRO_OID, "round", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"y", "x"}, {dec_type, int_type}, {dec_type, int_type}, {},
                   dec_type, "", true);
 
@@ -1874,11 +1874,11 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
 #undef BOOTSTRAP_TRIG_FN
 
-  // roundupto
-  func_context = new execution::functions::FunctionContext("roundupto", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
-                                                           execution::ast::Builtin::RoundUpTo);
+  // round2
+  func_context = new execution::functions::FunctionContext("round", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
+                                                           execution::ast::Builtin::Round2);
   txn->RegisterAbortAction([=]() { delete func_context; });
-  SetProcCtxPtr(txn, postgres::ROUNDUPTO_PRO_OID, func_context);
+  SetProcCtxPtr(txn, postgres::ROUND2_PRO_OID, func_context);
 
   // lower
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1744,6 +1744,7 @@ void DatabaseCatalog::BootstrapLanguages(const common::ManagedPointer<transactio
 
 void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::TransactionContext> txn) {
   auto dec_type = GetTypeOidForType(type::TypeId::DECIMAL);
+  auto int_type = GetTypeOidForType(type::TypeId::INTEGER);
 
   // ATan2
   CreateProcedure(txn, postgres::ATAN2_PRO_OID, "atan2", postgres::INTERNAL_LANGUAGE_OID,
@@ -1781,7 +1782,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // round up to
   CreateProcedure(txn, postgres::ROUNDUPTO_PRO_OID, "roundupto", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"y", "x"}, {dec_type, dec_type}, {dec_type, dec_type}, {},
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"y", "x"}, {dec_type, int_type}, {dec_type, int_type}, {},
                   dec_type, "", true);
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
@@ -1836,7 +1837,7 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   func_context = new execution::functions::FunctionContext("roundupto", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
                                                                 execution::ast::Builtin::RoundUpTo);
   txn->RegisterAbortAction([=]() { delete func_context; });
-  SetProcCtxPtr(txn, postgres::ATAN2_PRO_OID, func_context);
+  SetProcCtxPtr(txn, postgres::ROUNDUPTO_PRO_OID, func_context);
 
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1777,10 +1777,12 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // round
   BOOTSTRAP_TRIG_FN("round", postgres::ROUND_PRO_OID, execution::ast::Builtin::Round)
+#undef BOOTSTRAP_TRIG_FN
 
   // round up to
-  BOOTSTRAP_TRIG_FN("roundupto", postgres::ROUNDUPTO_PRO_OID, execution::ast::Builtin::RoundUpTo)
-#undef BOOTSTRAP_TRIG_FN
+  CreateProcedure(txn, postgres::ROUNDUPTO_PRO_OID, "roundupto", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"y", "x"}, {dec_type, dec_type}, {dec_type, dec_type}, {},
+                  dec_type, "", true);
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
 
@@ -1829,6 +1831,12 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   // round
   BOOTSTRAP_TRIG_FN("round", postgres::ROUND_PRO_OID, execution::ast::Builtin::Round)
 #undef BOOTSTRAP_TRIG_FN
+
+  // round up to
+  func_context = new execution::functions::FunctionContext("roundupto", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
+                                                                execution::ast::Builtin::RoundUpTo);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+  SetProcCtxPtr(txn, postgres::ATAN2_PRO_OID, func_context);
 
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1425,7 +1425,7 @@ void DatabaseCatalog::TearDown(const common::ManagedPointer<transaction::Transac
 
     for (auto expr : expressions) delete expr;
 
-    for (auto udf_ctxt : func_contexts) delete udf_ctxt;
+    for (auto func_ctxt : func_contexts) delete func_ctxt;
   };
 
   // No new transactions can see these object but there may be deferred index
@@ -1968,16 +1968,16 @@ common::ManagedPointer<execution::functions::FunctionContext> DatabaseCatalog::G
 
 common::ManagedPointer<execution::functions::FunctionContext> DatabaseCatalog::GetFunctionContext(
     const common::ManagedPointer<transaction::TransactionContext> txn, catalog::proc_oid_t proc_oid) {
-  auto udf_ctx = GetProcCtxPtr(txn, proc_oid);
-  if (udf_ctx == nullptr) {
+  auto func_ctx = GetProcCtxPtr(txn, proc_oid);
+  if (func_ctx == nullptr) {
     if (IS_BUILTIN_PROC(proc_oid)) {
       BootstrapProcContexts(txn);
     } else {
       UNREACHABLE("We don't support dynamically added udf's yet");
     }
-    udf_ctx = GetProcCtxPtr(txn, proc_oid);
+    func_ctx = GetProcCtxPtr(txn, proc_oid);
   }
-  return udf_ctx;
+  return func_ctx;
 }
 
 bool DatabaseCatalog::CreateTableEntry(const common::ManagedPointer<transaction::TransactionContext> txn,

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1775,6 +1775,11 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
 
+  // round
+  BOOTSTRAP_TRIG_FN("round", postgres::ROUND_PRO_OID, execution::ast::Builtin::Round)
+
+  // round up to
+  BOOTSTRAP_TRIG_FN("roundupto", postgres::ROUNDUPTO_PRO_OID, execution::ast::Builtin::RoundUpTo)
 #undef BOOTSTRAP_TRIG_FN
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
@@ -1820,6 +1825,9 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
+
+  // round
+  BOOTSTRAP_TRIG_FN("round", postgres::ROUND_PRO_OID, execution::ast::Builtin::Round)
 #undef BOOTSTRAP_TRIG_FN
 
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1809,18 +1809,18 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, str_type, "", true);
 
+  // TODO(tanujnay112): no op codes for lower and upper yet
+
   // length
   CreateProcedure(txn, postgres::LENGTH_PRO_OID, "length", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
-
-  // TODO(tanujnay112): no op codes for lower and upper yet
 
   BootstrapProcContexts(txn);
 }
 
 void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transaction::TransactionContext> txn) {
-  auto func_context = new execution::functions::FunctionContext("atan2", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
-                                                                execution::ast::Builtin::ATan2);
+  auto func_context = new execution::functions::FunctionContext(
+      "atan2", type::TypeId::DECIMAL, {type::TypeId::DECIMAL, type::TypeId::DECIMAL}, execution::ast::Builtin::ATan2);
   txn->RegisterAbortAction([=]() { delete func_context; });
   SetProcCtxPtr(txn, postgres::ATAN2_PRO_OID, func_context);
 
@@ -1875,10 +1875,10 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 #undef BOOTSTRAP_TRIG_FN
 
   // round2
-  func_context = new execution::functions::FunctionContext("round", type::TypeId::DECIMAL, {type::TypeId::DECIMAL},
-                                                           execution::ast::Builtin::Round2);
-  txn->RegisterAbortAction([=]() { delete func_context; });
+  func_context = new execution::functions::FunctionContext(
+      "round", type::TypeId::DECIMAL, {type::TypeId::DECIMAL, type::TypeId::INTEGER}, execution::ast::Builtin::Round2);
   SetProcCtxPtr(txn, postgres::ROUND2_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
 
   // lower
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2311,7 +2311,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
         return;
       }
 
-      // this function returns a integer
+      // this function returns an integer
       sql_type = ast::BuiltinType::Integer;
       break;
     }
@@ -2338,7 +2338,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
         return;
       }
 
-      // this function returns a integer
+      // this function returns an integer
       sql_type = ast::BuiltinType::Integer;
       break;
     }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2698,10 +2698,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
       break;
     }
     case ast::Builtin::Lower:
-    case ast::Builtin::Length: {
-      CheckBuiltinStringCall(call, builtin);
-      break;
-    }
+    case ast::Builtin::Length:
     case ast::Builtin::Position: {
       CheckBuiltinStringCall(call, builtin);
       break;

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1330,7 +1330,9 @@ void Sema::CheckMathTrigCall(ast::CallExpr *call, ast::Builtin builtin) {
     case ast::Builtin::Tan:
     case ast::Builtin::ACos:
     case ast::Builtin::ASin:
-    case ast::Builtin::ATan: {
+    case ast::Builtin::ATan:
+    case ast::Builtin::Sqrt:
+    case ast::Builtin::Cbrt: {
       if (!CheckArgCount(call, 1)) {
         return;
       }
@@ -2526,7 +2528,9 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::Cos:
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:
-    case ast::Builtin::Tan: {
+    case ast::Builtin::Tan:
+    case ast::Builtin::Sqrt:
+    case ast::Builtin::Cbrt: {
       CheckMathTrigCall(call, builtin);
       break;
     }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2254,6 +2254,33 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::StringVal;
       break;
     }
+    case ast::Builtin::Length: {
+      // check to make sure this function has two arguments
+      if (!CheckArgCount(call, 2)) {
+        return;
+      }
+
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
+
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // this function returns a integer
+      sql_type = ast::BuiltinType::Integer;
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string call!!");
   }
@@ -2601,7 +2628,8 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
       CheckBuiltinParamCall(call, builtin);
       break;
     }
-    case ast::Builtin::Lower: {
+    case ast::Builtin::Lower:
+    case ast::Builtin::Length: {
       CheckBuiltinStringCall(call, builtin);
       break;
     }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1348,7 +1348,7 @@ void Sema::CheckMathTrigCall(ast::CallExpr *call, ast::Builtin builtin) {
       }
       break;
     }
-    case ast::Builtin::RoundUpTo: {
+    case ast::Builtin::Round2: {
       // input arguments may include decimal places
       if (!CheckArgCount(call, 2)) {
         return;
@@ -2585,7 +2585,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::Sqrt:
     case ast::Builtin::Cbrt:
     case ast::Builtin::Round:
-    case ast::Builtin::RoundUpTo: {
+    case ast::Builtin::Round2: {
       CheckMathTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1539,8 +1539,8 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       Emitter()->Emit(Bytecode::Round, dest, src);
       break;
     }
-    case ast::Builtin::RoundUpTo: {
-      Emitter()->Emit(Bytecode::RoundUpTo, dest, src, VisitExpressionForRValue(call->Arguments()[1]));
+    case ast::Builtin::Round2: {
+      Emitter()->Emit(Bytecode::Round2, dest, src, VisitExpressionForRValue(call->Arguments()[1]));
       break;
     }
     default: {
@@ -2277,7 +2277,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::Sqrt:
     case ast::Builtin::Cbrt:
     case ast::Builtin::Round:
-    case ast::Builtin::RoundUpTo: {
+    case ast::Builtin::Round2: {
       VisitBuiltinTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1492,7 +1492,7 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       break;
     }
     case ast::Builtin::ATan2: {
-      Emitter()->Emit(Bytecode::Atan2, dest, src);
+      Emitter()->Emit(Bytecode::Atan2, dest, src, VisitExpressionForRValue(call->Arguments()[1]));
       break;
     }
     case ast::Builtin::Cos: {
@@ -1516,7 +1516,7 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       break;
     }
     case ast::Builtin::RoundUpTo: {
-      Emitter()->Emit(Bytecode::RoundUpTo, dest, src);
+      Emitter()->Emit(Bytecode::RoundUpTo, dest, src, VisitExpressionForRValue(call->Arguments()[1]));
       break;
     }
     default: {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2049,6 +2049,10 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
       Emitter()->Emit(Bytecode::Lower, exec_ctx, ret, input_string);
       break;
     }
+    case ast::Builtin::Length: {
+      Emitter()->Emit(Bytecode::Length, exec_ctx, ret, input_string);
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string function!");
   }
@@ -2337,7 +2341,8 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       break;
     }
 
-    case ast::Builtin::Lower: {
+    case ast::Builtin::Lower:
+    case ast::Builtin::Length: {
       VisitBuiltinStringCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2390,17 +2390,12 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       VisitBuiltinParamCall(call, builtin);
       break;
     }
-
     case ast::Builtin::Lower:
+    case ast::Builtin::Position:
     case ast::Builtin::Length: {
       VisitBuiltinStringCall(call, builtin);
       break;
     }
-    case ast::Builtin::Position: {
-      VisitBuiltinStringCall(call, builtin);
-      break;
-    }
-
     default: {
       UNREACHABLE("Builtin not supported!");
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1511,6 +1511,14 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       Emitter()->Emit(Bytecode::Tan, dest, src);
       break;
     }
+    case ast::Builtin::Sqrt: {
+      Emitter()->Emit(Bytecode::Sqrt, dest, src);
+      break;
+    }
+    case ast::Builtin::Cbrt: {
+      Emitter()->Emit(Bytecode::Cbrt, dest, src);
+      break;
+    }
     default: {
       UNREACHABLE("Impossible trigonometric bytecode");
     }
@@ -2234,7 +2242,9 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::Cos:
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:
-    case ast::Builtin::Tan: {
+    case ast::Builtin::Tan:
+    case ast::Builtin::Sqrt:
+    case ast::Builtin::Cbrt: {
       VisitBuiltinTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1511,6 +1511,14 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       Emitter()->Emit(Bytecode::Tan, dest, src);
       break;
     }
+    case ast::Builtin::Round: {
+      Emitter()->Emit(Bytecode::Round, dest, src);
+      break;
+    }
+    case ast::Builtin::RoundUpTo: {
+      Emitter()->Emit(Bytecode::RoundUpTo, dest, src);
+      break;
+    }
     default: {
       UNREACHABLE("Impossible trigonometric bytecode");
     }
@@ -2234,7 +2242,9 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::Cos:
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:
-    case ast::Builtin::Tan: {
+    case ast::Builtin::Tan:
+    case ast::Builtin::Round:
+    case ast::Builtin::RoundUpTo: {
       VisitBuiltinTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1827,8 +1827,8 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   OP(Round2) : {
     auto *result = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());
     auto *v = frame->LocalAt<const sql::Real *>(READ_LOCAL_ID());
-    auto *scale = frame->LocalAt<const sql::Integer *>(READ_LOCAL_ID());
-    OpRound2(result, v, scale);
+    auto *precision = frame->LocalAt<const sql::Integer *>(READ_LOCAL_ID());
+    OpRound2(result, v, precision);
     DISPATCH_NEXT();
   }
 

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1819,10 +1819,16 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   UNARY_REAL_MATH_OP(Sign);
   UNARY_REAL_MATH_OP(Radians);
   UNARY_REAL_MATH_OP(Degrees);
-  UNARY_REAL_MATH_OP(Round);
   BINARY_REAL_MATH_OP(Atan2);
   BINARY_REAL_MATH_OP(Log);
   BINARY_REAL_MATH_OP(Pow);
+
+  OP(Round) : {
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *v = frame->LocalAt<const sql::Real *>(READ_LOCAL_ID());
+    OpRound(result, v);
+    DISPATCH_NEXT();
+  }
 
   OP(RoundUpTo) : {
     auto *result = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1819,16 +1819,10 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   UNARY_REAL_MATH_OP(Sign);
   UNARY_REAL_MATH_OP(Radians);
   UNARY_REAL_MATH_OP(Degrees);
+  UNARY_REAL_MATH_OP(Round);
   BINARY_REAL_MATH_OP(Atan2);
   BINARY_REAL_MATH_OP(Log);
   BINARY_REAL_MATH_OP(Pow);
-
-  OP(Round) : {
-    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
-    auto *v = frame->LocalAt<const sql::Real *>(READ_LOCAL_ID());
-    OpRound(result, v);
-    DISPATCH_NEXT();
-  }
 
   OP(RoundUpTo) : {
     auto *result = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1824,11 +1824,11 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   BINARY_REAL_MATH_OP(Log);
   BINARY_REAL_MATH_OP(Pow);
 
-  OP(RoundUpTo) : {
+  OP(Round2) : {
     auto *result = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());
     auto *v = frame->LocalAt<const sql::Real *>(READ_LOCAL_ID());
     auto *scale = frame->LocalAt<const sql::Integer *>(READ_LOCAL_ID());
-    OpRoundUpTo(result, v, scale);
+    OpRound2(result, v, scale);
     DISPATCH_NEXT();
   }
 

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -326,15 +326,15 @@ class CatalogAccessor {
   proc_oid_t GetProcOid(const std::string &procname, const std::vector<type_oid_t> &all_arg_types);
 
   /**
-   * Sets the proc context pointer column of proc_oid to udf_context
+   * Sets the proc context pointer column of proc_oid to func_context
    * @param proc_oid The proc_oid whose pointer column we are setting here
-   * @param udf_context The context object to set to
+   * @param func_context The context object to set to
    * @return False if the given proc_oid is invalid, True if else
    */
-  bool SetProcCtxPtr(proc_oid_t proc_oid, const execution::functions::FunctionContext *udf_context);
+  bool SetProcCtxPtr(proc_oid_t proc_oid, const execution::functions::FunctionContext *func_context);
 
   /**
-   * Gets the proc context pointer column of proc_oid to udf_context
+   * Gets the proc context pointer column of proc_oid
    * @param proc_oid The proc_oid whose pointer column we are getting here
    * @return nullptr if proc_oid is either invalid or there is no context object set for this proc_oid
    */

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -363,7 +363,7 @@ class DatabaseCatalog {
       common::ManagedPointer<transaction::TransactionContext> txn, catalog::proc_oid_t proc_oid);
 
   /**
-   * Gets the proc context pointer column of proc_oid to func_context
+   * Gets the proc context pointer column of proc_oid
    * @param txn transaction to use
    * @param proc_oid The proc_oid whose pointer column we are getting here
    * @return nullptr if proc_oid is either invalid or there is no context object set for this proc_oid

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -79,9 +79,9 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
-constexpr proc_oid_t SQRT_PRO_OID = proc_oid_t(130);
-constexpr proc_oid_t CBRT_PRO_OID = proc_oid_t(131);
 
 constexpr proc_oid_t LENGTH_PRO_OID = proc_oid_t(114);
+constexpr proc_oid_t SQRT_PRO_OID = proc_oid_t(130);
+constexpr proc_oid_t CBRT_PRO_OID = proc_oid_t(131);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -79,6 +79,7 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
-constexpr proc_oid_t LENGTH_PRO_OID = proc_oid_t(93);
+
+constexpr proc_oid_t LENGTH_PRO_OID = proc_oid_t(114);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -79,5 +79,6 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
+constexpr proc_oid_t LENGTH_PRO_OID = proc_oid_t(93);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -77,6 +77,8 @@ constexpr proc_oid_t SIN_PRO_OID = proc_oid_t(89);
 // TODO(tanujnay112) This overflows into the next internal oid range and will continue to do so
 constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
+constexpr proc_oid_t ROUND_PRO_OID = proc_oid_t(136);
+constexpr proc_oid_t ROUNDUPTO_PRO_OID = proc_oid_t(200);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
 

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -88,6 +88,6 @@ constexpr proc_oid_t LENGTH_PRO_OID = proc_oid_t(114);
 constexpr proc_oid_t SQRT_PRO_OID = proc_oid_t(130);
 constexpr proc_oid_t CBRT_PRO_OID = proc_oid_t(131);
 constexpr proc_oid_t ROUND_PRO_OID = proc_oid_t(136);
-constexpr proc_oid_t ROUNDUPTO_PRO_OID = proc_oid_t(200);
+constexpr proc_oid_t ROUND2_PRO_OID = proc_oid_t(157);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -79,5 +79,7 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
+constexpr proc_oid_t SQRT_PRO_OID = proc_oid_t(130);
+constexpr proc_oid_t CBRT_PRO_OID = proc_oid_t(131);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -158,7 +158,7 @@ namespace terrier::execution::ast {
   F(Sqrt, sqrt)                                                         \
   F(Cbrt, cbrt)                                                         \
   F(Round, round)                                                       \
-  F(RoundUpTo, roundUpTo)                                               \
+  F(Round2, round2)                                                     \
                                                                         \
   /* Generic */                                                         \
   F(SizeOf, sizeOf)                                                     \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -151,6 +151,8 @@ namespace terrier::execution::ast {
   F(Cot, cot)                                                           \
   F(Sin, sin)                                                           \
   F(Tan, tan)                                                           \
+  F(Round, round)                                                       \
+  F(RoundUpTo, roundUpTo)                                               \
                                                                         \
   /* Generic */                                                         \
   F(SizeOf, sizeOf)                                                     \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -244,7 +244,8 @@ namespace terrier::execution::ast {
   F(GetParamString, getParamString)                                     \
                                                                         \
   /* String functions */                                                \
-  F(Lower, lower)
+  F(Lower, lower)                                                       \
+  F(Length, length)
 
 /**
  * Enum of builtins

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -151,10 +151,13 @@ namespace terrier::execution::ast {
   F(Cot, cot)                                                           \
   F(Sin, sin)                                                           \
   F(Tan, tan)                                                           \
+  F(Sqrt, sqrt)                                                         \
+  F(Cbrt, cbrt)                                                         \
                                                                         \
   /* Generic */                                                         \
   F(SizeOf, sizeOf)                                                     \
   F(PtrCast, ptrCast)                                                   \
+                                                                        \
                                                                         \
   /* Output Buffer */                                                   \
   F(OutputAlloc, outputAlloc)                                           \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -158,7 +158,6 @@ namespace terrier::execution::ast {
   F(SizeOf, sizeOf)                                                     \
   F(PtrCast, ptrCast)                                                   \
                                                                         \
-                                                                        \
   /* Output Buffer */                                                   \
   F(OutputAlloc, outputAlloc)                                           \
   F(OutputFinalize, outputFinalize)                                     \

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -223,7 +223,7 @@ class EXPORT ArithmeticFunctions {
   /**
    * Rounding with precision
    */
-  static void Round(Real *result, const Real &v, const Integer &precision);
+  static void Round2(Real *result, const Real &v, const Integer &precision);
 
   /**
    * Logarithm with base
@@ -392,7 +392,7 @@ inline void ArithmeticFunctions::Round(Real *result, const Real &v) {
   *result = Real(std::round(v.val_));
 }
 
-inline void ArithmeticFunctions::Round(Real *result, const Real &v, const Integer &precision) {
+inline void ArithmeticFunctions::Round2(Real *result, const Real &v, const Integer &precision) {
   if (v.is_null_ || precision.is_null_) {
     *result = Real::Null();
     return;

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -223,7 +223,7 @@ class EXPORT ArithmeticFunctions {
   /**
    * Rounding with scale
    */
-  static void RoundUpTo(Real *result, const Real &v, const Integer &scale);
+  static void Round(Real *result, const Real &v, const Integer &precision);
 
   /**
    * Logarithm with base
@@ -385,12 +385,12 @@ inline void ArithmeticFunctions::Degrees(Real *result, const Real &v) {
   *result = Real(v.val_ * 180.0 / M_PI);
 }
 
-inline void ArithmeticFunctions::RoundUpTo(Real *result, const Real &v, const Integer &scale) {
-  if (v.is_null_ || scale.is_null_) {
+inline void ArithmeticFunctions::Round(Real *result, const Real &v, const Integer &precision) {
+  if (v.is_null_ || precision.is_null_) {
     *result = Real::Null();
     return;
   }
-  *result = Real(std::round(v.val_ * std::pow(10.0, scale.val_)) / std::pow(10.0, scale.val_));
+  *result = Real(std::round(v.val_ * std::pow(10.0, precision.val_)) / std::pow(10.0, precision.val_));
 }
 
 inline void ArithmeticFunctions::Log(Real *result, const Real &base, const Real &val) {

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -218,7 +218,7 @@ class EXPORT ArithmeticFunctions {
   /**
    * Round to nearest
    */
-  static void Round(Real *result, const Real &v);
+  static void Round(Integer *result, const Real &v);
 
   /**
    * Rounding with scale
@@ -384,12 +384,12 @@ inline void ArithmeticFunctions::Degrees(Real *result, const Real &v) {
   *result = Real(v.val_ * 180.0 / M_PI);
 }
 
-inline void ArithmeticFunctions::Round(Real *result, const Real &v) {
+inline void ArithmeticFunctions::Round(Integer *result, const Real &v) {
   if (v.is_null_) {
-    *result = Real::Null();
+    *result = Integer::Null();
     return;
   }
-  *result = Real(v.val_ + ((v.val_ < 0) ? -0.5 : 0.5));
+  *result = Integer(v.val_ + ((v.val_ < 0) ? -0.5 : 0.5));
 }
 
 inline void ArithmeticFunctions::RoundUpTo(Real *result, const Real &v, const Integer &scale) {

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -349,6 +349,7 @@ UNARY_MATH_EXPENSIVE_HIDE_NULL(Ln, Real, Real, std::log);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Log2, Real, Real, std::log2);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Log10, Real, Real, std::log10);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Exp, Real, Real, std::exp);
+UNARY_MATH_EXPENSIVE_HIDE_NULL(Round, Real, Real, std::round);
 
 BINARY_MATH_EXPENSIVE_HIDE_NULL(Atan2, Real, Real, Real, std::atan2);
 BINARY_MATH_EXPENSIVE_HIDE_NULL(Pow, Real, Real, Real, std::pow);
@@ -384,20 +385,12 @@ inline void ArithmeticFunctions::Degrees(Real *result, const Real &v) {
   *result = Real(v.val_ * 180.0 / M_PI);
 }
 
-inline void ArithmeticFunctions::Round(Real *result, const Real &v) {
-  if (v.is_null_) {
-    *result = Real::Null();
-    return;
-  }
-  *result = Real(false, double(int(v.val_ + ((v.val_ < 0) ? -0.5 : 0.5))));
-}
-
 inline void ArithmeticFunctions::RoundUpTo(Real *result, const Real &v, const Integer &scale) {
   if (v.is_null_ || scale.is_null_) {
     *result = Real::Null();
     return;
   }
-  *result = Real(std::floor(v.val_ * std::pow(10.0, scale.val_) + 0.5) / std::pow(10.0, scale.val_));
+  *result = Real(std::round(v.val_ * std::pow(10.0, scale.val_)) / std::pow(10.0, scale.val_));
 }
 
 inline void ArithmeticFunctions::Log(Real *result, const Real &base, const Real &val) {

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -218,7 +218,7 @@ class EXPORT ArithmeticFunctions {
   /**
    * Round to nearest
    */
-  static void Round(Integer *result, const Real &v);
+  static void Round(Real *result, const Real &v);
 
   /**
    * Rounding with scale
@@ -384,12 +384,12 @@ inline void ArithmeticFunctions::Degrees(Real *result, const Real &v) {
   *result = Real(v.val_ * 180.0 / M_PI);
 }
 
-inline void ArithmeticFunctions::Round(Integer *result, const Real &v) {
+inline void ArithmeticFunctions::Round(Real *result, const Real &v) {
   if (v.is_null_) {
-    *result = Integer::Null();
+    *result = Real::Null();
     return;
   }
-  *result = Integer(v.val_ + ((v.val_ < 0) ? -0.5 : 0.5));
+  *result = Real(false, double(int(v.val_ + ((v.val_ < 0) ? -0.5 : 0.5))));
 }
 
 inline void ArithmeticFunctions::RoundUpTo(Real *result, const Real &v, const Integer &scale) {

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -221,7 +221,7 @@ class EXPORT ArithmeticFunctions {
   static void Round(Real *result, const Real &v);
 
   /**
-   * Rounding with scale
+   * Rounding with precision
    */
   static void Round(Real *result, const Real &v, const Integer &precision);
 
@@ -349,7 +349,6 @@ UNARY_MATH_EXPENSIVE_HIDE_NULL(Ln, Real, Real, std::log);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Log2, Real, Real, std::log2);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Log10, Real, Real, std::log10);
 UNARY_MATH_EXPENSIVE_HIDE_NULL(Exp, Real, Real, std::exp);
-UNARY_MATH_EXPENSIVE_HIDE_NULL(Round, Real, Real, std::round);
 
 BINARY_MATH_EXPENSIVE_HIDE_NULL(Atan2, Real, Real, Real, std::atan2);
 BINARY_MATH_EXPENSIVE_HIDE_NULL(Pow, Real, Real, Real, std::pow);
@@ -383,6 +382,14 @@ inline void ArithmeticFunctions::Degrees(Real *result, const Real &v) {
     return;
   }
   *result = Real(v.val_ * 180.0 / M_PI);
+}
+
+inline void ArithmeticFunctions::Round(Real *result, const Real &v) {
+  if (v.is_null_) {
+    *result = Real::Null();
+    return;
+  }
+  *result = Real(std::round(v.val_));
 }
 
 inline void ArithmeticFunctions::Round(Real *result, const Real &v, const Integer &precision) {

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1316,7 +1316,7 @@ VM_OP_WARM void OpRound(terrier::execution::sql::Real *result, const terrier::ex
 
 VM_OP_WARM void OpRound2(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *v,
                          const terrier::execution::sql::Integer *precision) {
-  terrier::execution::sql::ArithmeticFunctions::Round(result, *v, *precision);
+  terrier::execution::sql::ArithmeticFunctions::Round2(result, *v, *precision);
 }
 
 VM_OP_WARM void OpLog(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *base,

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1314,9 +1314,9 @@ VM_OP_WARM void OpRound(terrier::execution::sql::Real *result, const terrier::ex
   terrier::execution::sql::ArithmeticFunctions::Round(result, *v);
 }
 
-VM_OP_WARM void OpRoundUpTo(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *v,
-                            const terrier::execution::sql::Integer *scale) {
-  terrier::execution::sql::ArithmeticFunctions::RoundUpTo(result, *v, *scale);
+VM_OP_WARM void OpRound2(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *v,
+                         const terrier::execution::sql::Integer *precision) {
+  terrier::execution::sql::ArithmeticFunctions::Round(result, *v, *precision);
 }
 
 VM_OP_WARM void OpLog(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *base,

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1310,7 +1310,7 @@ VM_OP_WARM void OpDegrees(terrier::execution::sql::Real *result, const terrier::
   terrier::execution::sql::ArithmeticFunctions::Degrees(result, *v);
 }
 
-VM_OP_WARM void OpRound(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *v) {
+VM_OP_WARM void OpRound(terrier::execution::sql::Integer *result, const terrier::execution::sql::Real *v) {
   terrier::execution::sql::ArithmeticFunctions::Round(result, *v);
 }
 

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1310,7 +1310,7 @@ VM_OP_WARM void OpDegrees(terrier::execution::sql::Real *result, const terrier::
   terrier::execution::sql::ArithmeticFunctions::Degrees(result, *v);
 }
 
-VM_OP_WARM void OpRound(terrier::execution::sql::Integer *result, const terrier::execution::sql::Real *v) {
+VM_OP_WARM void OpRound(terrier::execution::sql::Real *result, const terrier::execution::sql::Real *v) {
   terrier::execution::sql::ArithmeticFunctions::Round(result, *v);
 }
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -456,7 +456,7 @@ namespace terrier::execution::vm {
   F(Radians, OperandType::Local, OperandType::Local)                                                                  \
   F(Degrees, OperandType::Local, OperandType::Local)                                                                  \
   F(Round, OperandType::Local, OperandType::Local)                                                                    \
-  F(RoundUpTo, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
+  F(Round2, OperandType::Local, OperandType::Local, OperandType::Local)                                               \
   F(Log, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
   F(Pow, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
                                                                                                                       \

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -309,7 +309,7 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
     ArithmeticFunctions::Sign(&result, input);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(0.0, result.val_);
-  };
+  }
 
   // RoundUpTo
   {
@@ -349,7 +349,7 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
     ArithmeticFunctions::RoundUpTo(&result, input, scale);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(-12.34, result.val_);
-  };
+  }
 }
 
 }  // namespace terrier::execution::sql::test

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -316,39 +316,39 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
   // RoundUpTo
   {
     Real input = Real::Null(), result = Real::Null();
-    Integer scale = Integer::Null();
+    Integer precision = Integer::Null();
 
     input = Real::Null();
-    scale = Integer(2);
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer(2);
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_TRUE(result.is_null_);
 
     input = Real(12.345);
-    scale = Integer::Null();
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer::Null();
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_TRUE(result.is_null_);
 
     input = Real(12.345);
-    scale = Integer(2);
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer(2);
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(12.35, result.val_);
 
     input = Real(12.344);
-    scale = Integer(2);
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer(2);
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(12.34, result.val_);
 
     input = Real(-12.345);
-    scale = Integer(2);
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer(2);
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(-12.35, result.val_);
 
     input = Real(-12.344);
-    scale = Integer(2);
-    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    precision = Integer(2);
+    ArithmeticFunctions::Round(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(-12.34, result.val_);
   }

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -1,5 +1,4 @@
 #include <limits>
-#include <limits>
 #include <memory>
 #include <random>
 #include <vector>
@@ -192,6 +191,7 @@ TEST_F(ArithmeticFunctionsTests, TrigFunctions) {
     EXPECT_FALSE(ret.is_null_);                 \
     EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
   }
+
 #define CHECK_SQL_FUNC(TPL_FUNC, C_FUNC) \
   CHECK_HANDLES_NULL(TPL_FUNC, C_FUNC)   \
   CHECK_HANDLES_NONNULL(TPL_FUNC, C_FUNC)

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -192,22 +192,6 @@ TEST_F(ArithmeticFunctionsTests, TrigFunctions) {
     EXPECT_FALSE(ret.is_null_);                 \
     EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
   }
-#define CHECK_HANDLES_INTNULL(TPL_FUNC, C_FUNC) \
-  {                                                \
-    Real arg(input);                            \
-    Integer ret(0);                              \
-    ArithmeticFunctions::TPL_FUNC(&ret, arg);   \
-    EXPECT_FALSE(ret.is_null_);                 \
-    EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
-  }
-#define CHECK_HANDLES_INTNONNULL(TPL_FUNC, C_FUNC) \
-  {                                                \
-    Real arg(input);                            \
-    Integer ret(0);                              \
-    ArithmeticFunctions::TPL_FUNC(&ret, arg);   \
-    EXPECT_FALSE(ret.is_null_);                 \
-    EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
-  }
 #define CHECK_SQL_FUNC(TPL_FUNC, C_FUNC) \
   CHECK_HANDLES_NULL(TPL_FUNC, C_FUNC)   \
   CHECK_HANDLES_NONNULL(TPL_FUNC, C_FUNC)
@@ -221,8 +205,7 @@ TEST_F(ArithmeticFunctionsTests, TrigFunctions) {
     CHECK_SQL_FUNC(Cosh, std::cosh);
     CHECK_SQL_FUNC(Tanh, std::tanh);
     CHECK_SQL_FUNC(Sinh, std::sinh);
-    CHECK_HANDLES_INTNONNULL(Round, std::round);
-    CHECK_HANDLES_INTNULL(Round, std::round);
+    CHECK_SQL_FUNC(Round, std::round);
   }
 
   for (const auto input : arc_inputs) {

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -1,4 +1,5 @@
 #include <limits>
+#include <limits>
 #include <memory>
 #include <random>
 #include <vector>
@@ -191,7 +192,22 @@ TEST_F(ArithmeticFunctionsTests, TrigFunctions) {
     EXPECT_FALSE(ret.is_null_);                 \
     EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
   }
-
+#define CHECK_HANDLES_INTNULL(TPL_FUNC, C_FUNC) \
+  {                                                \
+    Real arg(input);                            \
+    Integer ret(0);                              \
+    ArithmeticFunctions::TPL_FUNC(&ret, arg);   \
+    EXPECT_FALSE(ret.is_null_);                 \
+    EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
+  }
+#define CHECK_HANDLES_INTNONNULL(TPL_FUNC, C_FUNC) \
+  {                                                \
+    Real arg(input);                            \
+    Integer ret(0);                              \
+    ArithmeticFunctions::TPL_FUNC(&ret, arg);   \
+    EXPECT_FALSE(ret.is_null_);                 \
+    EXPECT_DOUBLE_EQ(C_FUNC(input), ret.val_);  \
+  }
 #define CHECK_SQL_FUNC(TPL_FUNC, C_FUNC) \
   CHECK_HANDLES_NULL(TPL_FUNC, C_FUNC)   \
   CHECK_HANDLES_NONNULL(TPL_FUNC, C_FUNC)
@@ -205,6 +221,8 @@ TEST_F(ArithmeticFunctionsTests, TrigFunctions) {
     CHECK_SQL_FUNC(Cosh, std::cosh);
     CHECK_SQL_FUNC(Tanh, std::tanh);
     CHECK_SQL_FUNC(Sinh, std::sinh);
+    CHECK_HANDLES_INTNONNULL(Round, std::round);
+    CHECK_HANDLES_INTNULL(Round, std::round);
   }
 
   for (const auto input : arc_inputs) {

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -313,42 +313,42 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
     EXPECT_DOUBLE_EQ(0.0, result.val_);
   }
 
-  // RoundUpTo
+  // Round2
   {
     Real input = Real::Null(), result = Real::Null();
     Integer precision = Integer::Null();
 
     input = Real::Null();
     precision = Integer(2);
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_TRUE(result.is_null_);
 
     input = Real(12.345);
     precision = Integer::Null();
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_TRUE(result.is_null_);
 
     input = Real(12.345);
     precision = Integer(2);
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(12.35, result.val_);
 
     input = Real(12.344);
     precision = Integer(2);
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(12.34, result.val_);
 
     input = Real(-12.345);
     precision = Integer(2);
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(-12.35, result.val_);
 
     input = Real(-12.344);
     precision = Integer(2);
-    ArithmeticFunctions::Round(&result, input, precision);
+    ArithmeticFunctions::Round2(&result, input, precision);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(-12.34, result.val_);
   }

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -278,6 +278,11 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
   CHECK_SQL_FUNC(Log10, std::log10, 50.123);
   CHECK_SQL_FUNC(Log10, std::log10, 100.234);
 
+  CHECK_SQL_FUNC(Round, std::round, 100.4);
+  CHECK_SQL_FUNC(Round, std::round, 100.5);
+  CHECK_SQL_FUNC(Round, std::round, -100.4);
+  CHECK_SQL_FUNC(Round, std::round, -100.5);
+
 #undef CHECK_SQL_FUNC
 #undef CHECK_HANDLES_NONNULL
 #undef CHECK_HANDLES_NULL
@@ -302,6 +307,46 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
     ArithmeticFunctions::Sign(&result, input);
     EXPECT_FALSE(result.is_null_);
     EXPECT_DOUBLE_EQ(0.0, result.val_);
+  };
+
+  // RoundUpTo
+  {
+    Real input = Real::Null(), result = Real::Null();
+    Integer scale = Integer::Null();
+
+    input = Real::Null();
+    scale = Integer(2);
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_TRUE(result.is_null_);
+
+    input = Real(12.345);
+    scale = Integer::Null();
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_TRUE(result.is_null_);
+
+    input = Real(12.345);
+    scale = Integer(2);
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_DOUBLE_EQ(12.35, result.val_);
+
+    input = Real(12.344);
+    scale = Integer(2);
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_DOUBLE_EQ(12.34, result.val_);
+
+    input = Real(-12.345);
+    scale = Integer(2);
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_DOUBLE_EQ(-12.35, result.val_);
+
+    input = Real(-12.344);
+    scale = Integer(2);
+    ArithmeticFunctions::RoundUpTo(&result, input, scale);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_DOUBLE_EQ(-12.34, result.val_);
   };
 }
 

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -245,9 +245,11 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
 
   CHECK_SQL_FUNC(Sqrt, std::sqrt, 4.0);
   CHECK_SQL_FUNC(Sqrt, std::sqrt, 1.0);
+  CHECK_SQL_FUNC(Sqrt, std::sqrt, 213.5);
 
   CHECK_SQL_FUNC(Cbrt, std::cbrt, 4.0);
   CHECK_SQL_FUNC(Cbrt, std::cbrt, 1.0);
+  CHECK_SQL_FUNC(Cbrt, std::cbrt, 82.3);
 
   CHECK_SQL_FUNC(Exp, std::exp, 4.0);
   CHECK_SQL_FUNC(Exp, std::exp, 1.0);

--- a/test/execution/arithmetic_functions_test.cpp
+++ b/test/execution/arithmetic_functions_test.cpp
@@ -246,11 +246,13 @@ TEST_F(ArithmeticFunctionsTests, MathFuncs) {
 
   CHECK_SQL_FUNC(Sqrt, std::sqrt, 4.0);
   CHECK_SQL_FUNC(Sqrt, std::sqrt, 1.0);
-  CHECK_SQL_FUNC(Sqrt, std::sqrt, 213.5);
+  CHECK_SQL_FUNC(Sqrt, std::sqrt, 50.1);
+  CHECK_SQL_FUNC(Sqrt, std::sqrt, 100.234);
 
   CHECK_SQL_FUNC(Cbrt, std::cbrt, 4.0);
-  CHECK_SQL_FUNC(Cbrt, std::cbrt, 1.0);
-  CHECK_SQL_FUNC(Cbrt, std::cbrt, 82.3);
+  CHECK_SQL_FUNC(Cbrt, std::cbrt, -1.0);
+  CHECK_SQL_FUNC(Cbrt, std::cbrt, 50.1);
+  CHECK_SQL_FUNC(Cbrt, std::cbrt, -100.234);
 
   CHECK_SQL_FUNC(Exp, std::exp, 4.0);
   CHECK_SQL_FUNC(Exp, std::exp, 1.0);

--- a/test/execution/string_functions_test.cpp
+++ b/test/execution/string_functions_test.cpp
@@ -287,6 +287,34 @@ TEST_F(StringFunctionsTests, Rpad) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(StringFunctionsTests, Length) {
+  // Nulls
+  {
+    auto x = StringVal::Null();
+    auto result = Integer(0);
+
+    StringFunctions::Length(Ctx(), &result, x);
+    EXPECT_TRUE(result.is_null_);
+  }
+
+  // Zero length
+  {
+    auto x = StringVal("");
+    auto result = Integer(0);
+
+    StringFunctions::Length(Ctx(), &result, x);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_EQ(0, result.val_);
+  }
+
+  auto x = StringVal("test");
+  auto result = Integer(0);
+  StringFunctions::Length(Ctx(), &result, x);
+  EXPECT_FALSE(result.is_null_);
+  EXPECT_EQ(4, result.val_);
+}
+
+// NOLINTNEXTLINE
 TEST_F(StringFunctionsTests, Lower) {
   // Nulls
   {


### PR DESCRIPTION
We have added support for functions `LENGTH`, `SQRT`, `CBRT`, `ROUND`. `ROUND` supports both `ROUND(value)` and `ROUND(value, precision)`.

A minor update is made on `checkIntRow` and `checkStringRow`. We find the if and else branches are exactly the same, so we have simplified it.

During the implementation of `ROUND`, we found a bug of `ATAN2`, which results in an error when calling a math function with two parameters. So we have fixed this in `bytecode_generator.cpp`.
