### PR TITLE
Hackathon: Add LIKE and NOT LIKE operators

### DIFF
--- a/script/testing/junit/src/TestUtility.java
+++ b/script/testing/junit/src/TestUtility.java
@@ -78,7 +78,7 @@ public class TestUtility {
     }
     
     /**
-    * Check a single row of real queried values against expected values
+    * Check a single row of string queried values against expected values
     *
     * @param rs              resultset, with cursor at the desired row
     * @param columns         column names
@@ -88,6 +88,25 @@ public class TestUtility {
         assertEquals(columns.length, expected.length);
         for (int i = 0; i < columns.length; i++) {
             String val = (String)rs.getObject(columns[i]);
+            if (expected[i] == null) {
+                assertEquals(expected[i], val);
+            } else {
+                assertEquals(expected[i], val);
+            }
+        }
+    }
+
+    /**
+    * Check a single row of boolean queried values against expected values
+    *
+    * @param rs              resultset, with cursor at the desired row
+    * @param columns         column names
+    * @param expected expected values of columns
+    */
+    public void checkBooleanRow(ResultSet rs, String[] columns, Boolean[] expected) throws SQLException {
+        assertEquals(columns.length, expected.length);
+        for (int i = 0; i < columns.length; i++) {
+            Boolean val = (Boolean)rs.getObject(columns[i]);
             if (expected[i] == null) {
                 assertEquals(expected[i], val);
             } else {

--- a/src/execution/compiler/expression/comparison_translator.cpp
+++ b/src/execution/compiler/expression/comparison_translator.cpp
@@ -31,6 +31,12 @@ ast::Expr *ComparisonTranslator::DeriveExpr(ExpressionEvaluator *evaluator) {
     case terrier::parser::ExpressionType::COMPARE_NOT_EQUAL:
       op_token = parsing::Token::Type::BANG_EQUAL;
       break;
+    case terrier::parser::ExpressionType::COMPARE_LIKE:
+      op_token = parsing::Token::Type::LIKE;
+      break;
+    case terrier::parser::ExpressionType::COMPARE_NOT_LIKE:
+      op_token = parsing::Token::Type::NOT_LIKE;
+      break;
     default:
       UNREACHABLE("Unsupported expression");
   }

--- a/src/execution/sema/sema_expr.cpp
+++ b/src/execution/sema/sema_expr.cpp
@@ -75,6 +75,15 @@ void Sema::VisitComparisonOpExpr(ast::ComparisonOpExpr *node) {
       if (node->Right() != right) node->SetRight(right);
       break;
     }
+    case parsing::Token::Type::LIKE:
+    case parsing::Token::Type::NOT_LIKE: {
+      // NOLINTNEXTLINE
+      auto [result_type, left, right] = CheckLikeOperand(node->Op(), node->Position(), node->Left(), node->Right());
+      node->SetType(result_type);
+      if (node->Left() != left) node->SetLeft(left);
+      if (node->Right() != right) node->SetRight(right);
+      break;
+    }
     default: {
       EXECUTION_LOG_ERROR("{} is not a comparison operation", parsing::Token::GetString(node->Op()));
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2693,6 +2693,16 @@ void BytecodeGenerator::VisitSqlCompareOpExpr(ast::ComparisonOpExpr *compare) {
       COMPARISON_BYTECODE(code, NotEqual, builtin_kind);
       break;
     }
+    case parsing::Token::Type::LIKE: {
+      TERRIER_ASSERT(builtin_kind == ast::BuiltinType::Kind::StringVal, "argument should be of type string");
+      code = Bytecode::LikeStringVal;
+      break;
+    }
+    case parsing::Token::Type::NOT_LIKE: {
+      TERRIER_ASSERT(builtin_kind == ast::BuiltinType::Kind::StringVal, "argument should be of type string");
+      code = Bytecode::NotLikeStringVal;
+      break;
+    }
     default: {
       UNREACHABLE("Impossible binary operation");
     }

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -927,6 +927,22 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_CMP(NotEqual);
 #undef GEN_CMP
 
+  OP(LikeStringVal) : {
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());
+    auto *left = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *right = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    OpLikeStringVal(result, left, right);
+    DISPATCH_NEXT();
+  }
+
+  OP(NotLikeStringVal) : {
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());
+    auto *left = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *right = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    OpNotLikeStringVal(result, left, right);
+    DISPATCH_NEXT();
+  }
+
 #define GEN_UNARY_MATH_OPS(op)                                      \
   OP(op##Integer) : {                                               \
     auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID()); \

--- a/src/include/execution/compiler/translator_factory.h
+++ b/src/include/execution/compiler/translator_factory.h
@@ -60,7 +60,8 @@ class TranslatorFactory {
     return type == parser::ExpressionType::COMPARE_EQUAL || type == parser::ExpressionType::COMPARE_NOT_EQUAL ||
            type == parser::ExpressionType::COMPARE_LESS_THAN || type == parser::ExpressionType::COMPARE_GREATER_THAN ||
            type == parser::ExpressionType::COMPARE_LESS_THAN_OR_EQUAL_TO ||
-           type == parser::ExpressionType::COMPARE_GREATER_THAN_OR_EQUAL_TO;
+           type == parser::ExpressionType::COMPARE_GREATER_THAN_OR_EQUAL_TO ||
+           type == parser::ExpressionType::COMPARE_LIKE || type == parser::ExpressionType::COMPARE_NOT_LIKE;
   }
 
   /**

--- a/src/include/execution/parsing/token.h
+++ b/src/include/execution/parsing/token.h
@@ -51,6 +51,8 @@ namespace terrier::execution::parsing {
   T(GREATER_EQUAL, ">=", 6)                        \
   T(LESS, "<", 6)                                  \
   T(LESS_EQUAL, "<=", 6)                           \
+  T(LIKE, "like", 6)                               \
+  T(NOT_LIKE, "notlike", 6)                        \
                                                    \
   /* Identifiers and literals */                   \
   T(IDENTIFIER, "[ident]", 0)                      \
@@ -129,7 +131,7 @@ class Token {
    */
   static bool IsCompareOp(Type op) {
     return (static_cast<uint8_t>(Type::BANG_EQUAL) <= static_cast<uint8_t>(op) &&
-            static_cast<uint8_t>(op) <= static_cast<uint8_t>(Type::LESS_EQUAL));
+            static_cast<uint8_t>(op) <= static_cast<uint8_t>(Type::NOT_LIKE));
   }
 
   /**

--- a/src/include/execution/sema/sema.h
+++ b/src/include/execution/sema/sema.h
@@ -109,6 +109,8 @@ class Sema : public ast::AstVisitor<Sema> {
   CheckResult CheckComparisonOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left,
                                       ast::Expr *right);
 
+  CheckResult CheckLikeOperand(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left, ast::Expr *right);
+
   // Check the assignment of the expression to a variable or the target type.
   // Return true if the assignment is valid, and false otherwise.
   // Will also apply an implicit cast to make the assignment valid.

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -703,6 +703,18 @@ GEN_SQL_COMPARISONS(DateVal)
 GEN_SQL_COMPARISONS(TimestampVal)
 #undef GEN_SQL_COMPARISONS
 
+void OpLikeStringVal(terrier::execution::sql::BoolVal *const result,
+                     const terrier::execution::sql::StringVal *const left,
+                     const terrier::execution::sql::StringVal *const right) {
+  terrier::execution::sql::ComparisonFunctions::LikeStringVal(result, *left, *right);
+}
+
+void OpNotLikeStringVal(terrier::execution::sql::BoolVal *const result,
+                        const terrier::execution::sql::StringVal *const left,
+                        const terrier::execution::sql::StringVal *const right) {
+  terrier::execution::sql::ComparisonFunctions::NotLikeStringVal(result, *left, *right);
+}
+
 // ----------------------------------
 // SQL arithmetic
 // ---------------------------------

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -703,13 +703,13 @@ GEN_SQL_COMPARISONS(DateVal)
 GEN_SQL_COMPARISONS(TimestampVal)
 #undef GEN_SQL_COMPARISONS
 
-void OpLikeStringVal(terrier::execution::sql::BoolVal *const result,
+VM_OP_HOT void OpLikeStringVal(terrier::execution::sql::BoolVal *const result,
                      const terrier::execution::sql::StringVal *const left,
                      const terrier::execution::sql::StringVal *const right) {
   terrier::execution::sql::ComparisonFunctions::LikeStringVal(result, *left, *right);
 }
 
-void OpNotLikeStringVal(terrier::execution::sql::BoolVal *const result,
+VM_OP_HOT void OpNotLikeStringVal(terrier::execution::sql::BoolVal *const result,
                         const terrier::execution::sql::StringVal *const left,
                         const terrier::execution::sql::StringVal *const right) {
   terrier::execution::sql::ComparisonFunctions::NotLikeStringVal(result, *left, *right);

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -225,6 +225,8 @@ namespace terrier::execution::vm {
   F(GreaterThanEqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                         \
   F(EqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                    \
   F(NotEqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
+  F(LikeStringVal, OperandType::Local, OperandType::Local, OperandType::Local)                                        \
+  F(NotLikeStringVal, OperandType::Local, OperandType::Local, OperandType::Local)                                     \
                                                                                                                       \
   /* SQL value unary operations */                                                                                    \
   F(AbsInteger, OperandType::Local, OperandType::Local)                                                               \


### PR DESCRIPTION
This is implemented as a comparison operator (since that's what the parser provides), which is maybe dubious, since it requires adding to `token.h`? The other alternative would have been to rewrite it as a call to a builtin function when generating the AST by using a custom translator, similar to NotNullTranslator.

Also, because of the implementation as comparison operator, it seems like type checking is not strict enough. For instance, trying to execute `1 like 2` results in a crash.