### PR TITLE
Hackathon: Integration of LPad, LTrim, RPad, and RTrim

### DIFF
--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1778,6 +1778,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 #undef BOOTSTRAP_TRIG_FN
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
+  auto int_type = GetTypeOidForType(type::TypeId::INTEGER);
 
   // lower
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
@@ -1786,7 +1787,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   // lpad
   CreateProcedure(txn, postgres::LPAD_PRO_OID, "lpad", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
-                  {str_type, dec_type, str_type}, {str_type, dec_type, str_type}, {}, str_type, "", true);
+                  {str_type, dec_type, str_type}, {str_type, int_type, str_type}, {}, str_type, "", true);
 
   // ltrim2arg
   CreateProcedure(txn, postgres::LTRIM2ARG_PRO_OID, "ltrim", postgres::INTERNAL_LANGUAGE_OID,
@@ -1801,7 +1802,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   // rpad
   CreateProcedure(txn, postgres::RPAD_PRO_OID, "rpad", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
-                  {str_type, dec_type, str_type}, {str_type, dec_type, str_type}, {}, str_type, "", true);
+                  {str_type, dec_type, str_type}, {str_type, int_type, str_type}, {}, str_type, "", true);
 
   // rtrim2arg
   CreateProcedure(txn, postgres::RTRIM2ARG_PRO_OID, "rtrim", postgres::INTERNAL_LANGUAGE_OID,
@@ -1853,6 +1854,42 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("lpad", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Lpad, true);
+  SetProcCtxPtr(txn, postgres::LPAD_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("ltrim", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Ltrim, true);
+  SetProcCtxPtr(txn, postgres::LTRIM2ARG_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("ltrim", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Ltrim, true);
+  SetProcCtxPtr(txn, postgres::LTRIM1ARG_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("rpad", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Rpad, true);
+  SetProcCtxPtr(txn, postgres::RPAD_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("rtrim", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Rtrim, true);
+  SetProcCtxPtr(txn, postgres::RTRIM2ARG_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  func_context = new execution::functions::FunctionContext("rtrim", type::TypeId::VARCHAR,
+                                                           {type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Rtrim, true);
+  SetProcCtxPtr(txn, postgres::RTRIM1ARG_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 }
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1786,33 +1786,31 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
 
   // lpad
   CreateProcedure(txn, postgres::LPAD_PRO_OID, "lpad", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
-                  {str_type, dec_type, str_type}, {str_type, int_type, str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"}, {str_type, dec_type, str_type},
+                  {str_type, int_type, str_type}, {}, str_type, "", true);
 
   // ltrim2arg
   CreateProcedure(txn, postgres::LTRIM2ARG_PRO_OID, "ltrim", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"},
-                  {str_type, str_type}, {str_type, str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"}, {str_type, str_type},
+                  {str_type, str_type}, {}, str_type, "", true);
 
   // ltrim1arg
   CreateProcedure(txn, postgres::LTRIM1ARG_PRO_OID, "ltrim", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"},
-                  {str_type}, {str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, str_type, "", true);
 
   // rpad
   CreateProcedure(txn, postgres::RPAD_PRO_OID, "rpad", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
-                  {str_type, dec_type, str_type}, {str_type, int_type, str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"}, {str_type, dec_type, str_type},
+                  {str_type, int_type, str_type}, {}, str_type, "", true);
 
   // rtrim2arg
   CreateProcedure(txn, postgres::RTRIM2ARG_PRO_OID, "rtrim", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"},
-                  {str_type, str_type}, {str_type, str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"}, {str_type, str_type},
+                  {str_type, str_type}, {}, str_type, "", true);
 
   // rtrim1arg
   CreateProcedure(txn, postgres::RTRIM1ARG_PRO_OID, "rtrim", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"},
-                  {str_type}, {str_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, str_type, "", true);
 
   BootstrapProcContexts(txn);
 }
@@ -1856,9 +1854,9 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("lpad", type::TypeId::VARCHAR,
-                                                           {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
-                                                           execution::ast::Builtin::Lpad, true);
+  func_context = new execution::functions::FunctionContext(
+      "lpad", type::TypeId::VARCHAR, {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
+      execution::ast::Builtin::Lpad, true);
   SetProcCtxPtr(txn, postgres::LPAD_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
@@ -1868,15 +1866,14 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   SetProcCtxPtr(txn, postgres::LTRIM2ARG_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("ltrim", type::TypeId::VARCHAR,
-                                                           {type::TypeId::VARCHAR},
+  func_context = new execution::functions::FunctionContext("ltrim", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Ltrim, true);
   SetProcCtxPtr(txn, postgres::LTRIM1ARG_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("rpad", type::TypeId::VARCHAR,
-                                                           {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
-                                                           execution::ast::Builtin::Rpad, true);
+  func_context = new execution::functions::FunctionContext(
+      "rpad", type::TypeId::VARCHAR, {type::TypeId::VARCHAR, type::TypeId::INTEGER, type::TypeId::VARCHAR},
+      execution::ast::Builtin::Rpad, true);
   SetProcCtxPtr(txn, postgres::RPAD_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
@@ -1886,8 +1883,7 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   SetProcCtxPtr(txn, postgres::RTRIM2ARG_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("rtrim", type::TypeId::VARCHAR,
-                                                           {type::TypeId::VARCHAR},
+  func_context = new execution::functions::FunctionContext("rtrim", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Rtrim, true);
   SetProcCtxPtr(txn, postgres::RTRIM1ARG_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1783,7 +1783,35 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, str_type, "", true);
 
-  // TODO(tanujnay112): no op codes for lower and upper yet
+  // lpad
+  CreateProcedure(txn, postgres::LPAD_PRO_OID, "lpad", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
+                  {str_type, dec_type, str_type}, {str_type, dec_type, str_type}, {}, str_type, "", true);
+
+  // ltrim2arg
+  CreateProcedure(txn, postgres::LTRIM2ARG_PRO_OID, "ltrim", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"},
+                  {str_type, str_type}, {str_type, str_type}, {}, str_type, "", true);
+
+  // ltrim1arg
+  CreateProcedure(txn, postgres::LTRIM1ARG_PRO_OID, "ltrim", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"},
+                  {str_type}, {str_type}, {}, str_type, "", true);
+
+  // rpad
+  CreateProcedure(txn, postgres::RPAD_PRO_OID, "rpad", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "len", "pad"},
+                  {str_type, dec_type, str_type}, {str_type, dec_type, str_type}, {}, str_type, "", true);
+
+  // rtrim2arg
+  CreateProcedure(txn, postgres::RTRIM2ARG_PRO_OID, "rtrim", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str", "chars"},
+                  {str_type, str_type}, {str_type, str_type}, {}, str_type, "", true);
+
+  // rtrim1arg
+  CreateProcedure(txn, postgres::RTRIM1ARG_PRO_OID, "rtrim", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"},
+                  {str_type}, {str_type}, {}, str_type, "", true);
 
   BootstrapProcContexts(txn);
 }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2254,6 +2254,92 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::StringVal;
       break;
     }
+    case ast::Builtin::Lpad:
+    case ast::Builtin::Rpad: {
+        if(!CheckArgCount(call, 4)) {
+            return;
+        }
+
+        // checking to see if the first argument is an execution context
+        auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+        if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+            ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+            return;
+        }
+
+        // checking to see if the second argument is a string
+        auto *resolved_type = Resolve(call->Arguments()[1]);
+        if (resolved_type == nullptr) {
+            return;
+        }
+        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+            ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+            return;
+        }
+
+        // checking to see if the third argument is an integer
+        resolved_type = Resolve(call->Arguments()[2]);
+        if (resolved_type == nullptr) {
+            return;
+        }
+        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::Integer)) {
+            ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+            return;
+        }
+
+        // checking to see if the fourth argument is a string
+        resolved_type = Resolve(call->Arguments()[3]);
+        if (resolved_type == nullptr) {
+            return;
+        }
+        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+            ReportIncorrectCallArg(call, 3, ast::StringType::Get(GetContext()));
+            return;
+        }
+
+        // this function returns a string
+        sql_type = ast::BuiltinType::StringVal;
+        break;
+    }
+    case ast::Builtin::Ltrim:
+    case ast::Builtin::Rtrim: {
+        if(!CheckArgCount(call, 2) || !CheckArgCount(call, 3)) {
+            return;
+        }
+
+        // checking to see if the first argument is an execution context
+        auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+        if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+            ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+            return;
+        }
+
+        // checking to see if the second argument is a string
+        auto *resolved_type = Resolve(call->Arguments()[1]);
+        if (resolved_type == nullptr) {
+            return;
+        }
+        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+            ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+            return;
+        }
+
+        if (call->NumArgs() == 3) {
+            // checking to see if the third argument is a string
+            resolved_type = Resolve(call->Arguments()[2]);
+            if (resolved_type == nullptr) {
+                return;
+            }
+            if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+                ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+                return;
+            }
+        }
+
+        // this function returns a string
+        sql_type = ast::BuiltinType::StringVal;
+        break;
+    }
     default:
       UNREACHABLE("Unimplemented string call!!");
   }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2256,7 +2256,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
     }
     case ast::Builtin::Lpad:
     case ast::Builtin::Rpad: {
-      if(!CheckArgCount(call, 4)) {
+      if (!CheckArgCount(call, 4)) {
         return;
       }
 
@@ -2299,7 +2299,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
     }
     case ast::Builtin::Ltrim:
     case ast::Builtin::Rtrim: {
-      if(!CheckArgCount(call, 2) || !CheckArgCount(call, 3)) {
+      if (!CheckArgCount(call, 2) || !CheckArgCount(call, 3)) {
         return;
       }
 

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2256,89 +2256,89 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
     }
     case ast::Builtin::Lpad:
     case ast::Builtin::Rpad: {
-        if(!CheckArgCount(call, 4)) {
-            return;
-        }
+      if(!CheckArgCount(call, 4)) {
+        return;
+      }
 
-        // checking to see if the first argument is an execution context
-        auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
-        if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
-            ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
-            return;
-        }
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
 
-        // checking to see if the second argument is a string
-        auto *resolved_type = Resolve(call->Arguments()[1]);
-        if (resolved_type == nullptr) {
-            return;
-        }
-        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
-            ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
-            return;
-        }
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
 
-        // checking to see if the third argument is an integer
-        resolved_type = Resolve(call->Arguments()[2]);
-        if (resolved_type == nullptr) {
-            return;
-        }
-        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::Integer)) {
-            ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
-            return;
-        }
+      // checking to see if the third argument is an integer
+      resolved_type = Resolve(call->Arguments()[2]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::Integer)) {
+        ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+        return;
+      }
 
-        // checking to see if the fourth argument is a string
-        resolved_type = Resolve(call->Arguments()[3]);
-        if (resolved_type == nullptr) {
-            return;
-        }
-        if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
-            ReportIncorrectCallArg(call, 3, ast::StringType::Get(GetContext()));
-            return;
-        }
+      // checking to see if the fourth argument is a string
+      resolved_type = Resolve(call->Arguments()[3]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 3, ast::StringType::Get(GetContext()));
+        return;
+      }
 
-        // this function returns a string
-        sql_type = ast::BuiltinType::StringVal;
-        break;
+      // this function returns a string
+      sql_type = ast::BuiltinType::StringVal;
+      break;
     }
     case ast::Builtin::Ltrim:
     case ast::Builtin::Rtrim: {
-        if(!CheckArgCount(call, 2) || !CheckArgCount(call, 3)) {
-            return;
-        }
+      if(!CheckArgCount(call, 2) || !CheckArgCount(call, 3)) {
+        return;
+      }
 
-        // checking to see if the first argument is an execution context
-        auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
-        if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
-            ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
-            return;
-        }
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
 
-        // checking to see if the second argument is a string
-        auto *resolved_type = Resolve(call->Arguments()[1]);
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      if (call->NumArgs() == 3) {
+        // checking to see if the third argument is a string
+        resolved_type = Resolve(call->Arguments()[2]);
         if (resolved_type == nullptr) {
-            return;
+          return;
         }
         if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
-            ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
-            return;
+          ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+          return;
         }
+      }
 
-        if (call->NumArgs() == 3) {
-            // checking to see if the third argument is a string
-            resolved_type = Resolve(call->Arguments()[2]);
-            if (resolved_type == nullptr) {
-                return;
-            }
-            if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
-                ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
-                return;
-            }
-        }
-
-        // this function returns a string
-        sql_type = ast::BuiltinType::StringVal;
-        break;
+      // this function returns a string
+      sql_type = ast::BuiltinType::StringVal;
+      break;
     }
     default:
       UNREACHABLE("Unimplemented string call!!");

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2278,12 +2278,8 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       }
 
       // checking to see if the third argument is an integer
-      resolved_type = Resolve(call->Arguments()[2]);
-      if (resolved_type == nullptr) {
-        return;
-      }
-      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::Integer)) {
-        ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+      if (!call->Arguments()[2]->GetType()->IsIntegerType()) {
+        ReportIncorrectCallArg(call, 2, GetBuiltinType(ast::BuiltinType::Kind::Uint32));
         return;
       }
 

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -128,8 +128,8 @@ void StringFunctions::Lpad(exec::ExecutionContext *ctx, StringVal *result, const
     return;
   }
 
-  // If target length equals input length, nothing to do
-  if (len.val_ == str.len_) {
+  // If target length equals input length or padding is empty string, nothing to do
+  if (len.val_ == str.len_ || pad.len_ == 0) {
     *result = str;
     return;
   }
@@ -164,8 +164,8 @@ void StringFunctions::Rpad(exec::ExecutionContext *ctx, StringVal *result, const
     return;
   }
 
-  // If target length equals input length, nothing to do
-  if (len.val_ == str.len_) {
+  // If target length equals input length or padding is empty string, nothing to do
+  if (len.val_ == str.len_ || pad.len_ == 0) {
     *result = str;
     return;
   }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2042,11 +2042,45 @@ void BytecodeGenerator::VisitBuiltinParamCall(ast::CallExpr *call, ast::Builtin 
 
 void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
   LocalVar exec_ctx = VisitExpressionForRValue(call->Arguments()[0]);
-  LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
   LocalVar ret = ExecutionResult()->GetOrCreateDestination(call->GetType());
   switch (builtin) {
     case ast::Builtin::Lower: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       Emitter()->Emit(Bytecode::Lower, exec_ctx, ret, input_string);
+      break;
+    }
+    case ast::Builtin::Lpad: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      LocalVar len = VisitExpressionForRValue(call->Arguments()[2]);
+      LocalVar pad = VisitExpressionForRValue(call->Arguments()[3]);
+      Emitter()->Emit(Bytecode::LPad, exec_ctx, ret, input_string, len, pad);
+      break;
+    }
+    case ast::Builtin::Rpad: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      LocalVar len = VisitExpressionForRValue(call->Arguments()[2]);
+      LocalVar pad = VisitExpressionForRValue(call->Arguments()[3]);
+      Emitter()->Emit(Bytecode::RPad, exec_ctx, ret, input_string, len, pad);
+      break;
+    }
+    case ast::Builtin::Ltrim: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      if (call->NumArgs() == 2) {
+        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string);
+      } else {
+        LocalVar chars = VisitExpressionForRValue(call->Arguments()[2]);
+        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string, chars);
+      }
+      break;
+    }
+    case ast::Builtin::Rtrim: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      if (call->NumArgs() == 2) {
+        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string);
+      } else {
+        LocalVar chars = VisitExpressionForRValue(call->Arguments()[2]);
+        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string, chars);
+      }
       break;
     }
     default:
@@ -2337,7 +2371,11 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       break;
     }
 
-    case ast::Builtin::Lower: {
+    case ast::Builtin::Lower:
+    case ast::Builtin::Lpad:
+    case ast::Builtin::Ltrim:
+    case ast::Builtin::Rpad:
+    case ast::Builtin::Rtrim: {
       VisitBuiltinStringCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2066,20 +2066,20 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
     case ast::Builtin::Ltrim: {
       LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       if (call->NumArgs() == 2) {
-        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string);
+        Emitter()->Emit(Bytecode::LTrim1Arg, exec_ctx, ret, input_string);
       } else {
         LocalVar chars = VisitExpressionForRValue(call->Arguments()[2]);
-        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string, chars);
+        Emitter()->Emit(Bytecode::LTrim2Arg, exec_ctx, ret, input_string, chars);
       }
       break;
     }
     case ast::Builtin::Rtrim: {
       LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       if (call->NumArgs() == 2) {
-        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string);
+        Emitter()->Emit(Bytecode::RTrim1Arg, exec_ctx, ret, input_string);
       } else {
         LocalVar chars = VisitExpressionForRValue(call->Arguments()[2]);
-        Emitter()->Emit(Bytecode::LTrim, exec_ctx, ret, input_string, chars);
+        Emitter()->Emit(Bytecode::RTrim2Arg, exec_ctx, ret, input_string, chars);
       }
       break;
     }

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1874,12 +1874,20 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
-  OP(LTrim) : {
+  OP(LTrim2Arg) : {
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
     auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    OpLTrim(exec_ctx, result, input, chars);
+    OpLTrim3Arg(exec_ctx, result, input, chars);
+    DISPATCH_NEXT();
+  }
+
+  OP(LTrim1Arg) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpLTrim2Arg(exec_ctx, result, input);
     DISPATCH_NEXT();
   }
 

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1879,7 +1879,7 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
     auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    OpLTrim3Arg(exec_ctx, result, input, chars);
+    OpLTrim2Arg(exec_ctx, result, input, chars);
     DISPATCH_NEXT();
   }
 
@@ -1887,7 +1887,7 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    OpLTrim2Arg(exec_ctx, result, input);
+    OpLTrim1Arg(exec_ctx, result, input);
     DISPATCH_NEXT();
   }
 
@@ -1927,17 +1927,25 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
-  OP(RTrim) : {
-    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
-    auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
-    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    OpRTrim(exec_ctx, result, input, chars);
-    DISPATCH_NEXT();
-  }
+  OP(RTrim2Arg) : {
+  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+  auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+  auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+  auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+  OpRTrim2Arg(exec_ctx, result, input, chars);
+  DISPATCH_NEXT();
+}
+
+  OP(RTrim1Arg) : {
+  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+  auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+  auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+  OpRTrim1Arg(exec_ctx, result, input);
+  DISPATCH_NEXT();
+}
 
   OP(SplitPart) : {
-    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
     auto *delim = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1928,24 +1928,24 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   }
 
   OP(RTrim2Arg) : {
-  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
-  auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
-  auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-  auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-  OpRTrim2Arg(exec_ctx, result, input, chars);
-  DISPATCH_NEXT();
-}
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    auto *chars = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpRTrim2Arg(exec_ctx, result, input, chars);
+    DISPATCH_NEXT();
+  }
 
   OP(RTrim1Arg) : {
-  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
-  auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
-  auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-  OpRTrim1Arg(exec_ctx, result, input);
-  DISPATCH_NEXT();
-}
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpRTrim1Arg(exec_ctx, result, input);
+    DISPATCH_NEXT();
+  }
 
   OP(SplitPart) : {
-  auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
     auto *delim = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -79,5 +79,11 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
+constexpr proc_oid_t LPAD_PRO_OID = proc_oid_t(115);
+constexpr proc_oid_t LTRIM2ARG_PRO_OID = proc_oid_t(142);
+constexpr proc_oid_t LTRIM1ARG_PRO_OID = proc_oid_t(116);
+constexpr proc_oid_t RPAD_PRO_OID = proc_oid_t(121);
+constexpr proc_oid_t RTRIM2ARG_PRO_OID = proc_oid_t(144);
+constexpr proc_oid_t RTRIM1ARG_PRO_OID = proc_oid_t(120);
 
 }  // namespace terrier::catalog::postgres

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -244,7 +244,11 @@ namespace terrier::execution::ast {
   F(GetParamString, getParamString)                                     \
                                                                         \
   /* String functions */                                                \
-  F(Lower, lower)
+  F(Lower, lower)                                                       \
+  F(Lpad, lpad)                                                         \
+  F(Ltrim, ltrim)                                                       \
+  F(Rpad, rpad)                                                         \
+  F(Rtrim, rtrim)
 
 /**
  * Enum of builtins

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1371,17 +1371,16 @@ VM_OP_WARM void OpLPad(terrier::execution::exec::ExecutionContext *ctx, terrier:
   terrier::execution::sql::StringFunctions::Lpad(ctx, result, *str, *len, *pad);
 }
 
-VM_OP_WARM void OpLTrim3Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+VM_OP_WARM void OpLTrim2Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                         const terrier::execution::sql::StringVal *str,
                         const terrier::execution::sql::StringVal *chars) {
   terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str, *chars);
 }
 
-VM_OP_WARM void OpLTrim2Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+VM_OP_WARM void OpLTrim1Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                         const terrier::execution::sql::StringVal *str) {
   terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str);
 }
-
 
 VM_OP_WARM void OpRepeat(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                          const terrier::execution::sql::StringVal *str, const terrier::execution::sql::Integer *n) {
@@ -1404,10 +1403,15 @@ VM_OP_WARM void OpRPad(terrier::execution::exec::ExecutionContext *ctx, terrier:
   terrier::execution::sql::StringFunctions::Rpad(ctx, result, *str, *n, *pad);
 }
 
-VM_OP_WARM void OpRTrim(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
-                        const terrier::execution::sql::StringVal *str,
-                        const terrier::execution::sql::StringVal *chars) {
-  terrier::execution::sql::StringFunctions::Rtrim(ctx, result, *str, *chars);
+VM_OP_WARM void OpRTrim2Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+                            const terrier::execution::sql::StringVal *str,
+                            const terrier::execution::sql::StringVal *chars) {
+  terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str, *chars);
+}
+
+VM_OP_WARM void OpRTrim1Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+                            const terrier::execution::sql::StringVal *str) {
+  terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str);
 }
 
 VM_OP_WARM void OpSplitPart(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1371,11 +1371,17 @@ VM_OP_WARM void OpLPad(terrier::execution::exec::ExecutionContext *ctx, terrier:
   terrier::execution::sql::StringFunctions::Lpad(ctx, result, *str, *len, *pad);
 }
 
-VM_OP_WARM void OpLTrim(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+VM_OP_WARM void OpLTrim3Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                         const terrier::execution::sql::StringVal *str,
                         const terrier::execution::sql::StringVal *chars) {
   terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str, *chars);
 }
+
+VM_OP_WARM void OpLTrim2Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+                        const terrier::execution::sql::StringVal *str) {
+  terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str);
+}
+
 
 VM_OP_WARM void OpRepeat(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
                          const terrier::execution::sql::StringVal *str, const terrier::execution::sql::Integer *n) {

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1372,13 +1372,13 @@ VM_OP_WARM void OpLPad(terrier::execution::exec::ExecutionContext *ctx, terrier:
 }
 
 VM_OP_WARM void OpLTrim2Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
-                        const terrier::execution::sql::StringVal *str,
-                        const terrier::execution::sql::StringVal *chars) {
+                            const terrier::execution::sql::StringVal *str,
+                            const terrier::execution::sql::StringVal *chars) {
   terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str, *chars);
 }
 
 VM_OP_WARM void OpLTrim1Arg(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
-                        const terrier::execution::sql::StringVal *str) {
+                            const terrier::execution::sql::StringVal *str) {
   terrier::execution::sql::StringFunctions::Ltrim(ctx, result, *str);
 }
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -464,13 +464,13 @@ namespace terrier::execution::vm {
   F(Left, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Length, OperandType::Local, OperandType::Local, OperandType::Local)                                               \
   F(Lower, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
-  F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
+  F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
+  F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(Repeat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Reverse, OperandType::Local, OperandType::Local, OperandType::Local)                                              \
   F(Right, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
+  F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
+  F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(SplitPart, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -465,14 +465,14 @@ namespace terrier::execution::vm {
   F(Length, OperandType::Local, OperandType::Local, OperandType::Local)                                               \
   F(Lower, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
+  F(LTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
+  F(LTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(Repeat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Reverse, OperandType::Local, OperandType::Local, OperandType::Local)                                              \
   F(Right, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
   F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
+  F(RTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
+  F(RTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(SplitPart, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -464,12 +464,14 @@ namespace terrier::execution::vm {
   F(Left, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Length, OperandType::Local, OperandType::Local, OperandType::Local)                                               \
   F(Lower, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
-  F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
+  F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
+  F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
   F(LTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(Repeat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Reverse, OperandType::Local, OperandType::Local, OperandType::Local)                                              \
   F(Right, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
+  F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
+  F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
   F(RTrim, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(SplitPart, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -465,14 +465,14 @@ namespace terrier::execution::vm {
   F(Length, OperandType::Local, OperandType::Local, OperandType::Local)                                               \
   F(Lower, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(LPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(LTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(LTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
+  F(LTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                        \
+  F(LTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
   F(Repeat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Reverse, OperandType::Local, OperandType::Local, OperandType::Local)                                              \
   F(Right, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
   F(RPad, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)         \
-  F(RTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                            \
-  F(RTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
+  F(RTrim2Arg, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                        \
+  F(RTrim1Arg, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
   F(SplitPart, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \


### PR DESCRIPTION
This pull requests adds the 4 specified functions using the method specified [here](https://github.com/cmu-db/terrier/blob/master/src/include/execution/functions/HOW_TO_ADD_BUILTINS.md). Note that currently this doesn't work, but I wanted to put this here since 90% of the work is done.
Specifically, running 
```sql
CREATE TABLE test ( a varchar(25) ); 
INSERT INTO test ( a ) VALUES ( 'ABCDEF' );
SELECT LPAD(a, 3, 'ABC') FROM test;
```
Will result in a crash within `src/execution/sema/sema_builtin.cpp` with an invalid `ast::Builtin` type that has the value -54 according to CLion debugging.